### PR TITLE
Fix typo in RootViewCoordinator protocol

### DIFF
--- a/QLog/QLog/RootViewCoordinator.swift
+++ b/QLog/QLog/RootViewCoordinator.swift
@@ -9,10 +9,10 @@
 import Foundation
 import UIKit
 
-protocol RootViewCoontrollerProvider: AnyObject {
+protocol RootViewControllerProvider: AnyObject {
 
     var rootViewController: UIViewController { get }
 
 }
 
-typealias  RootViewCoordinator = Coordinator & RootViewCoontrollerProvider
+typealias RootViewCoordinator = Coordinator & RootViewControllerProvider


### PR DESCRIPTION
## Summary
- correct misspelled `RootViewControllerProvider` protocol in `RootViewCoordinator.swift`

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_687807a01e8c833389eb010c95a8bcd0